### PR TITLE
7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Set the language preference in ExpressionEngine Control Panel
 
 ## Changes Between Versions
-- [7.2.5 → 7.2.8]
+- [7.2.5 → 7.2.9]
 - [7.1.5 → 7.2.5](https://github.com/EllisLab/EE-Language-French/compare/973e11f...)
 - [6.0.3 → 7.1.5](https://github.com/EllisLab/EE-Language-French/compare/4f93475...973e11f)
 - [6.0.3 → 6.0.6](https://github.com/EllisLab/EE-Language-French/compare/ad4f27f...4f93475)

--- a/user/language/french/content_lang.php
+++ b/user/language/french/content_lang.php
@@ -32,7 +32,7 @@ $lang = array(
 
     'btn_create_new' => 'Créer Nouvelle',
 
-    'btn_create_new_entry_in_channel' => 'Nouvelle dans %s',
+    'btn_create_new_entry_in_channel' => 'Nouveau dans %s',
 
     'btn_edit_comment' => 'Sauvegarder',
 


### PR DESCRIPTION
In content_lang.php
Line 35 --> 'btn_create_new_entry_in_channel' => 'Nouvelle dans %s', 
being replaced by
Line 35 --> 'btn_create_new_entry_in_channel' => 'Nouveau dans %s', 
This  "masculine" version for "new" appears more standard or better suited.
