### PR TITLE
EE French 738 Update fieldtypes_lang.php

### DIFF
--- a/user/language/french/fieldtypes_lang.php
+++ b/user/language/french/fieldtypes_lang.php
@@ -195,6 +195,10 @@ $lang = array(
     'file_dnd_upload_new' => 'Télécharger nouveau',
     
     'file_dnd_create_directory' => 'Créer un Nouveau Répertoire',
+
+	'file_dnd_no_directories' => 'Il n\'y a pas de répertoires de téléchargement disponibles',
+
+     'file_dnd_no_directories_desc' => 'Ce champ est limité au répertoire de téléchargement non disponible pour le membre et le site actuels.',
     
     'file_grid_vertical_layout_title' => 'Agencement du fichier Grille',
 


### PR DESCRIPTION
Two additions, no deletion.

'file_dnd_no_directories' => 'Il n\'y a pas de répertoires de téléchargement disponibles',

    
 'file_dnd_no_directories_desc' => 'Ce champ est limité au répertoire de téléchargement non disponible pour le membre et le site actuels.',