### PR TITLE
Missing comma on line 69 in form_validation_lang.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Set the language preference in ExpressionEngine Control Panel
 
 ## Changes Between Versions
-- [7.4.5 -> 7.4.6](https://github.com/Biscuiterie975/EE-English-7X/commit/f4cc7d59e8a0d89ed74c090d1ddff1ecc9c09cdb)
+- [7.4.5 -> 7.4.9](https://github.com/Biscuiterie975/EE-French-7x/commit/c6dbfef82e7ddab89cdf66620752c674b852549d)
 - [7.4.4 -> 7.4.5](https://github.com/EllisLab/EE-Language-French/commit/ea88512e9256ccc911c9007512285e09a95b3b51)
 - [7.4.2 -> 7.4.4](https://github.com/EllisLab/EE-Language-French/compare/master...Biscuiterie975:EE-French-7x:patch-51)
 - [7.4 -> 7.4.2](https://github.com/EllisLab/EE-Language-French/commit/82537e4d6c4bb875be2047bceef5de9105a153ff)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Set the language preference in ExpressionEngine Control Panel
 
 ## Changes Between Versions
-- [7.4.5 -> 7.4.9](https://github.com/Biscuiterie975/EE-French-7x/commit/c6dbfef82e7ddab89cdf66620752c674b852549d)
+- [7.4.5 -> 7.4.10](https://github.com/Biscuiterie975/EE-French-7x/commit/6d5575eabd2326f3c39d7d2354d565d45863dc70)
 - [7.4.4 -> 7.4.5](https://github.com/EllisLab/EE-Language-French/commit/ea88512e9256ccc911c9007512285e09a95b3b51)
 - [7.4.2 -> 7.4.4](https://github.com/EllisLab/EE-Language-French/compare/master...Biscuiterie975:EE-French-7x:patch-51)
 - [7.4 -> 7.4.2](https://github.com/EllisLab/EE-Language-French/commit/82537e4d6c4bb875be2047bceef5de9105a153ff)

--- a/user/language/french/form_validation_lang.php
+++ b/user/language/french/form_validation_lang.php
@@ -66,7 +66,7 @@ $lang = array(
 	
 	'unique_among_channel_fields' => 'Ce champ doit être unique et ne peut correspondre au nom abrégé d\'un champ de canal.',
 
-	'unique_among_member_fields'  => 'Ce champ doit être unique et ne peut correspondre au nom abrégé d\'un champ de membre.'
+	'unique_among_member_fields'  => 'Ce champ doit être unique et ne peut correspondre au nom abrégé d\'un champ de membre.',
 
     'unique_among_field_groups' => 'Ce champ doit être unique et ne peut correspondre au nom abrégé d\'un groupe de champs.',
 	

--- a/user/language/french/imglib_lang.php
+++ b/user/language/french/imglib_lang.php
@@ -31,6 +31,8 @@ $lang = array(
 
 'imglib_save_failed' => "Impossible d'enregistrer l'image. Merci de vous assurer que l'image et son répertoire son inscriptibles.",
 
+'imglib_properties_failed' => 'Impossible de rassembler les propriétés de l\'image. Veuillez vous assurer que l\'image est valide et lisible.",
+
 'imglib_source_image_required' => "Vous devez préciser une image source dans vos préférences.",
 
 'imglib_unsafe_config' => 'Un élément de configuration contient des caractères qui ne sont pas sûrs quand votre système fonctionne en environnement shell.',


### PR DESCRIPTION
Added a comma at the end of:

'unique_among_member_fields'  => 'Ce champ doit être unique et ne peut correspondre au nom abrégé d\'un champ de membre.',